### PR TITLE
Check mouseleave event is a MouseEvent

### DIFF
--- a/src/exit-intent.js
+++ b/src/exit-intent.js
@@ -45,6 +45,9 @@ export default function ExitIntent (options = {}) {
   // EVENT LISTENERS
   // DESKTOP: MOUSEOUT event
   const onMouse = () => {
+    if (!(e instanceof MouseEvent)) {
+      return;
+    }
     log('mouseleave')
     display()
   }


### PR DESCRIPTION
Ran into a problem in which `display()` is called when the mouse
leaves a graph's tooltip; the difference being the event's instance
was `UIEvent`. By adding a condition, `display()` will only get called
when it's a `MouseEvent`.