### PR TITLE
Fix `e is not defined` error

### DIFF
--- a/src/exit-intent.js
+++ b/src/exit-intent.js
@@ -44,7 +44,7 @@ export default function ExitIntent (options = {}) {
   // ===========================
   // EVENT LISTENERS
   // DESKTOP: MOUSEOUT event
-  const onMouse = () => {
+  const onMouse = (e) => {
     if (!(e instanceof MouseEvent)) {
       return;
     }


### PR DESCRIPTION
Pass `e` as parameter of onMouse